### PR TITLE
Match any IP address, not just the default

### DIFF
--- a/libraries/zookeeper_helper.rb
+++ b/libraries/zookeeper_helper.rb
@@ -93,7 +93,13 @@ module ZookeeperHelper
 
   def does_server_match_node? server
     # We check that the server value is either the nodes fqdn, hostname or ipaddress.
-    identities = [node["fqdn"], node["hostname"], node["ipaddress"]]
+    identities = [node["fqdn"], node["hostname"]]
+
+    node["network"]["interfaces"].each_value do |interface|
+      interface["addresses"].each_key do |address|
+          identities << address
+      end
+    end
 
     # We also include ec2 identities as well
     identities << node["machinename"] if node.attribute?("machinename")


### PR DESCRIPTION
Before this update, when `does_server_match_node?` executes it only
checks the default route's ip address (node["ipaddress"]).

With this change it will now match _any_ ip address attached to the
node, including ipv6 addresses.
