### PR TITLE
Fix for CentOS 7 while executing "apache_zookeeper::service_systemd" recipe.

### DIFF
--- a/recipes/service_systemd.rb
+++ b/recipes/service_systemd.rb
@@ -6,7 +6,8 @@ include_recipe 'apache_zookeeper::_attributes'
 
 dist_dir, conf_dir = value_for_platform_family(
   ['debian'] => %w{ debian default },
-  ['fedora'] => %w{ redhat sysconfig }
+  ['fedora'] => %w{ redhat sysconfig },
+  ['rhel']   => %w{ redhat sysconfig }
 )
 
 # Reload systemd on template change


### PR DESCRIPTION
* Add rhel family family support when reported by CentOS 7.